### PR TITLE
Feature/order history page

### DIFF
--- a/src/features/orders/orderApi.js
+++ b/src/features/orders/orderApi.js
@@ -46,13 +46,13 @@ export const orderApi = createApi({
       invalidatesTags: (result, error, { orderId }) => [{ type: "Order", id: orderId }],
     }),
     // 取得所有訂單
-    // getOrders: builder.query({
-    //   query: () => "/orders",
-    //   providesTags: result =>
-    //     result
-    //       ? [...result.map(({ id }) => ({ type: "Order", id })), { type: "Order", id: "LIST" }]
-    //       : [{ type: "Order", id: "LIST" }],
-    // }),
+    getOrders: builder.query({
+      query: () => "/orders",
+      providesTags: result =>
+        result
+          ? [...result.map(({ id }) => ({ type: "Order", id })), { type: "Order", id: "LIST" }]
+          : [{ type: "Order", id: "LIST" }],
+    }),
   }),
 });
 
@@ -63,4 +63,5 @@ export const {
   useGetOrderByIdQuery,
   useLazyGetOrderByIdQuery,
   usePrefetch,
+  useGetOrdersQuery,
 } = orderApi;

--- a/src/pages/MemberAccountPages/OrderHistoryPage.jsx
+++ b/src/pages/MemberAccountPages/OrderHistoryPage.jsx
@@ -1,35 +1,17 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useGetOrdersQuery } from "@/features/orders/orderApi";
 
 function OrderHistoryPage() {
   const [activeTab, setActiveTab] = useState("all");
   const [searchTerm, setSearchTerm] = useState("");
+  const { data: orders = [], isLoading, isError } = useGetOrdersQuery();
 
-  const orders = [
-    {
-      id: "A123456789",
-      product: "Leica SF 60 閃光燈",
-      createdAt: "2025-06-01",
-      total: 12800,
-      payment: "信用卡",
-      status: "completed",
-    },
-    {
-      id: "B987654321",
-      product: "Fujifilm X100V",
-      createdAt: "2025-05-20",
-      total: 7600,
-      payment: "ATM轉帳",
-      status: "cancelled",
-    },
-    {
-      id: "C456789123",
-      product: "Sony RX100 VII",
-      createdAt: "2025-04-15",
-      total: 98000,
-      payment: "信用卡",
-      status: "completed",
-    },
-  ];
+  const countAll = orders.length;
+  const countCompleted = orders.filter(o => o.status === "completed").length;
+  const countCancelled = orders.filter(o => o.status === "cancell").length;
+  console.log("取得訂單：", orders);
+
   const filteredOrders = orders
     //狀態篩選
     .filter(order => activeTab === "all" || order.status === activeTab)
@@ -51,9 +33,9 @@ function OrderHistoryPage() {
               {/* 切換按鈕區 */}
               <div className="d-flex gap-4 border-bottom mb-4">
                 {[
-                  { key: "all", label: "全部", count: 3 },
-                  { key: "completed", label: "已完成", count: 3 },
-                  { key: "cancelled", label: "已取消", count: 0 },
+                  { key: "all", label: "全部", count: countAll },
+                  { key: "completed", label: "已完成", count: countCompleted },
+                  { key: "cancelled", label: "已取消", count: countCancelled },
                 ].map(tab => (
                   <button
                     key={tab.key}
@@ -65,6 +47,14 @@ function OrderHistoryPage() {
                   </button>
                 ))}
               </div>
+              {isLoading && (
+                <div className="text-center py-5">
+                  <div className="spinner-border text-secondary" role="status">
+                    <span className="visually-hidden">Loading...</span>
+                  </div>
+                  <p className="mt-2 text-muted">載入中...</p>
+                </div>
+              )}
               {/* search space */}
               <div className="mb-4">
                 <input
@@ -89,31 +79,42 @@ function OrderHistoryPage() {
               </div>
 
               {/* 訂單內容 */}
-              {filteredOrders.map(order => (
-                <div
-                  key={order.id}
-                  className="row align-items-center px-2 py-3 border-bottom"
-                  style={{ fontSize: "0.95rem" }}
-                >
-                  <div className="col-6 col-md-2">{order.createdAt}</div>
-                  <div className="col-6 col-md-2">{order.id}</div>
-                  <div className="col-6 col-md-3">{order.product}</div>
-                  <div className="col-6 col-md-1">{order.total}</div>
-                  <div className="col-6 col-md-2">{order.payment}</div>
-                  <div className="col-6 col-md-2">
-                    {order.status === "completed" ? (
-                      <span className="text-muted">已完成</span>
-                    ) : order.status === "cancelled" ? (
-                      <span className="text-muted">已取消</span>
-                    ) : (
-                      <span className="text-muted">處理中</span>
-                    )}
-                  </div>
+              {filteredOrders.length === 0 ? (
+                <div className="text-center text-muted py-5 w-100">
+                  <p className="mb-3 fs-5">查無符合條件的訂單</p>
+                  <Link to="/" className="btn btn-outline-secondary">
+                    前往首頁探索商品
+                  </Link>
                 </div>
-              ))}
-              <div className="text-center text-muted py-4 " style={{ fontSize: "0.9rem" }}>
-                沒有更多訂單資料
-              </div>
+              ) : (
+                filteredOrders.map(order => (
+                  <div
+                    key={order.id}
+                    className="row align-items-center px-2 py-3 border-bottom"
+                    style={{ fontSize: "0.95rem" }}
+                  >
+                    <div className="col-6 col-md-2">{order.createdAt}</div>
+                    <div className="col-6 col-md-2">{order.id}</div>
+                    <div className="col-6 col-md-3">{order.product}</div>
+                    <div className="col-6 col-md-1">{order.total}</div>
+                    <div className="col-6 col-md-2">{order.payment}</div>
+                    <div className="col-6 col-md-2">
+                      {order.status === "completed" ? (
+                        <span className="text-muted">已完成</span>
+                      ) : order.status === "cancelled" ? (
+                        <span className="text-muted">已取消</span>
+                      ) : (
+                        <span className="text-muted">處理中</span>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+              {filteredOrders.length > 0 && (
+                <div className="text-center text-muted py-4 " style={{ fontSize: "0.9rem" }}>
+                  沒有更多訂單資料
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/MemberAccountPages/OrderHistoryPage.jsx
+++ b/src/pages/MemberAccountPages/OrderHistoryPage.jsx
@@ -1,7 +1,39 @@
+import { useState } from "react";
+
 function OrderHistoryPage() {
+  const [activeTab, setActiveTab] = useState("all");
   return (
     <>
-      <div>這是訂單資訊分頁</div>
+      <div className="container">
+        <div className="row g-4">
+          <div className="col-lg-12">
+            <div className="bg-white rounded p-4">
+              <h4 className="mb-5 mb-md-0">訂單資訊</h4>
+              {/* <hr /> */}
+              {/* 切換按鈕區 */}
+              <div className="d-flex gap-4 border-bottom mb-4">
+                {[
+                  { key: "all", label: "全部", count: 3 },
+                  { key: "completed", label: "已完成", count: 3 },
+                  { key: "cancelled", label: "已取消", count: 0 },
+                ].map(tab => (
+                  <button
+                    key={tab.key}
+                    className={`btn btn-link px-0 ${activeTab === tab.key ? "fw-bold text-warning" : "text-muted"}`}
+                    onClick={() => setActiveTab(tab.key)}
+                  >
+                    {tab.label} <sup>{tab.count}</sup>
+                  </button>
+                ))}
+              </div>
+            </div>
+            {/* 測試 */}
+            <p>
+              目前選擇的篩選條件是：<strong>{activeTab}</strong>
+            </p>
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/src/pages/MemberAccountPages/OrderHistoryPage.jsx
+++ b/src/pages/MemberAccountPages/OrderHistoryPage.jsx
@@ -2,13 +2,51 @@ import { useState } from "react";
 
 function OrderHistoryPage() {
   const [activeTab, setActiveTab] = useState("all");
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const orders = [
+    {
+      id: "A123456789",
+      product: "Leica SF 60 閃光燈",
+      createdAt: "2025-06-01",
+      total: 12800,
+      payment: "信用卡",
+      status: "completed",
+    },
+    {
+      id: "B987654321",
+      product: "Fujifilm X100V",
+      createdAt: "2025-05-20",
+      total: 7600,
+      payment: "ATM轉帳",
+      status: "cancelled",
+    },
+    {
+      id: "C456789123",
+      product: "Sony RX100 VII",
+      createdAt: "2025-04-15",
+      total: 98000,
+      payment: "信用卡",
+      status: "completed",
+    },
+  ];
+  const filteredOrders = orders
+    //狀態篩選
+    .filter(order => activeTab === "all" || order.status === activeTab)
+    //文字篩選
+    .filter(
+      order =>
+        order.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        order.product.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
   return (
     <>
       <div className="container">
         <div className="row g-4">
           <div className="col-lg-12">
             <div className="bg-white rounded p-4">
-              <h4 className="mb-5 mb-md-0">訂單資訊</h4>
+              <h4 className="mb-5 py-2 mb-md-0">訂單資訊</h4>
               {/* <hr /> */}
               {/* 切換按鈕區 */}
               <div className="d-flex gap-4 border-bottom mb-4">
@@ -19,18 +57,64 @@ function OrderHistoryPage() {
                 ].map(tab => (
                   <button
                     key={tab.key}
-                    className={`btn btn-link px-0 ${activeTab === tab.key ? "fw-bold text-warning" : "text-muted"}`}
+                    className={`btn btn-link px-0 ${activeTab === tab.key ? "fw-bold" : "text-muted"}`}
+                    style={activeTab === tab.key ? { color: "#8BB0B7" } : {}}
                     onClick={() => setActiveTab(tab.key)}
                   >
                     {tab.label} <sup>{tab.count}</sup>
                   </button>
                 ))}
               </div>
+              {/* search space */}
+              <div className="mb-4">
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="搜尋訂單編號或商品名稱"
+                  value={searchTerm}
+                  onChange={e => setSearchTerm(e.target.value)}
+                />
+              </div>
+              {/* 表頭欄位名稱 */}
+              <div
+                className="row text-muted px-2 mb-2 py-2 bg-light"
+                style={{ backgroundColor: "#F2F2F2", fontSize: "0.9rem" }}
+              >
+                <div className="col-6 col-md-2">訂單成立日期</div>
+                <div className="col-6 col-md-2">訂單編號</div>
+                <div className="col-6 col-md-3">購入商品</div>
+                <div className="col-6 col-md-1">總金額</div>
+                <div className="col-6 col-md-2">付款方式</div>
+                <div className="col-6 col-md-2">狀態</div>
+              </div>
+
+              {/* 訂單內容 */}
+              {filteredOrders.map(order => (
+                <div
+                  key={order.id}
+                  className="row align-items-center px-2 py-3 border-bottom"
+                  style={{ fontSize: "0.95rem" }}
+                >
+                  <div className="col-6 col-md-2">{order.createdAt}</div>
+                  <div className="col-6 col-md-2">{order.id}</div>
+                  <div className="col-6 col-md-3">{order.product}</div>
+                  <div className="col-6 col-md-1">{order.total}</div>
+                  <div className="col-6 col-md-2">{order.payment}</div>
+                  <div className="col-6 col-md-2">
+                    {order.status === "completed" ? (
+                      <span className="text-muted">已完成</span>
+                    ) : order.status === "cancelled" ? (
+                      <span className="text-muted">已取消</span>
+                    ) : (
+                      <span className="text-muted">處理中</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+              <div className="text-center text-muted py-4 " style={{ fontSize: "0.9rem" }}>
+                沒有更多訂單資料
+              </div>
             </div>
-            {/* 測試 */}
-            <p>
-              目前選擇的篩選條件是：<strong>{activeTab}</strong>
-            </p>
           </div>
         </div>
       </div>

--- a/src/pages/MemberAccountPages/WishlistPage.jsx
+++ b/src/pages/MemberAccountPages/WishlistPage.jsx
@@ -12,7 +12,7 @@ function mapWishlistData(apiData) {
     name: item.Products.name,
     primary_image: item.Products.primary_image,
     liked: true,
-    original_price: item.Products.original_price, // 目前後端沒接到
+    original_price: item.Products.original_price,
     selling_price: item.Products.selling_price,
     created_at: item.created_at,
   }));

--- a/src/pages/MemberAccountPages/WishlistPage.jsx
+++ b/src/pages/MemberAccountPages/WishlistPage.jsx
@@ -78,7 +78,6 @@ function WishlistPage() {
       </div>
     );
   }
-  console.log("收藏資料：", data);
   return (
     <div className="container">
       <div className="row g-4">

--- a/src/pages/MemberAccountPages/WishlistPage.jsx
+++ b/src/pages/MemberAccountPages/WishlistPage.jsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { useGetWishlistProductsQuery } from "@/features/wishlist/wishlistApi";
 import { useGetUserProfileQuery } from "@/features/users/userApi";
+import { useState, useMemo } from "react";
 import WishlistCard from "@/components/productpage/WishlistCard";
 
 function mapWishlistData(apiData) {
@@ -11,8 +12,9 @@ function mapWishlistData(apiData) {
     name: item.Products.name,
     primary_image: item.Products.primary_image,
     liked: true,
-    original_price: item.Products.original_price, // 目前後端沒提供
+    original_price: item.Products.original_price, // 目前後端沒接到
     selling_price: item.Products.selling_price,
+    created_at: item.created_at,
   }));
 }
 
@@ -25,6 +27,38 @@ function WishlistPage() {
 
   const isPageLoading = isLoading || isUserLoading;
   const location = useLocation();
+
+  const [sortOption, setSortOption] = useState("default");
+
+  const sortedWishlist = useMemo(() => {
+    if (!wishlist.length) return [];
+
+    const sorted = [...wishlist];
+    switch (sortOption) {
+      case "price-high":
+        sorted.sort((a, b) => b.selling_price - a.selling_price);
+        break;
+      case "price-low":
+        sorted.sort((a, b) => a.selling_price - b.selling_price);
+        break;
+      case "newest":
+        sorted.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+        break;
+      case "oldest":
+        sorted.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+        break;
+
+      default:
+        break;
+    }
+
+    return sorted;
+  }, [wishlist, sortOption]);
+
+  const handleSortChange = e => {
+    console.log("目前排序選項：", e.target.value);
+    setSortOption(e.target.value);
+  };
 
   if (isPageLoading) {
     return (
@@ -44,7 +78,7 @@ function WishlistPage() {
       </div>
     );
   }
-
+  console.log("收藏資料：", data);
   return (
     <div className="container">
       <div className="row g-4">
@@ -53,18 +87,18 @@ function WishlistPage() {
           <div className="bg-white rounded  p-4">
             <div className="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center">
               <h4 className="mb-3 mb-md-0">收藏資訊</h4>
-              <select className="form-select w-auto">
-                <option>排序方式：預設</option>
-                <option>價格（由高到低）</option>
-                <option>價格（由低到高）</option>
-                <option>上架順序（由新到舊）</option>
-                <option>上架順序（由舊到新）</option>
+              <select className="form-select w-auto" value={sortOption} onChange={handleSortChange}>
+                <option value="default">排序方式：預設</option>
+                <option value="price-high">價格（由高到低）</option>
+                <option value="price-low">價格（由低到高）</option>
+                <option value="newest">上架順序（由新到舊）</option>
+                <option value="oldest">上架順序（由舊到新）</option>
               </select>
             </div>
             <hr />
             <div className="row g-4">
               {wishlist.length > 0 ? (
-                wishlist.map(product => (
+                sortedWishlist.map(product => (
                   <div className="col-xl-3 col-lg-4 col-md-6 col-sm-6" key={product.id}>
                     <WishlistCard product={product} />
                   </div>


### PR DESCRIPTION
-套用統一的會員中心外框與排版
-加入「全部 / 已完成 / 已取消」三個狀態 tab
-新增欄位標題：訂單成立日期、訂單編號、購入商品、總金額、付款方式、狀態
-串接 getOrders API 取得該用戶所有訂單資料
-根據 tab 切換不同狀態的訂單列表
-使用訂單編號或商品名稱的關鍵字搜尋
-新增錯誤處理與空資料處理
-資料尚未載入時顯示 loading動畫